### PR TITLE
Added support for ResponseType Attribute on Controller Actions

### DIFF
--- a/WebApiProxy.Server/MetadataProvider.cs
+++ b/WebApiProxy.Server/MetadataProvider.cs
@@ -56,7 +56,7 @@ namespace WebApiProxy.Server
                                                       Url = a.RelativePath,
 
                                                       Description = a.Documentation ?? "",
-                                                      ReturnType = ParseType(a.ActionDescriptor.ReturnType),
+                                                      ReturnType = ParseType(a.ResponseDescription.ResponseType ?? a.ResponseDescription.DeclaredType),
                                                       Type = a.HttpMethod.Method
                                                   }
                               },


### PR DESCRIPTION
As per http://www.asp.net/web-api/overview/web-api-routing-and-actions/action-results, the recommended way to return an Action response with a status code other than 200 is to set the return type of the action to `HttpResponseMessage`.
You can then either return an `HttpResponseMessage` directly or use the `Request.CreateResponse` method if you want to include the object.

As an example:

``` csharp
[ResponseType(typeof(User))]
public HttpResponseMessage GetUser(HttpRequestMessage request, int userId, DateTime lastModifiedAtClient)
{
    var user = new DataEntities().Users.First(p => p.Id == userId);
    if (user.LastModified <= lastModifiedAtClient)
    {
         return new HttpResponseMessage(HttpStatusCode.NotModified);
    }
    return Request.CreateResponse(HttpStatusCode.OK, user);
}
```

The current version of WebApiProxy will set the return type of this action to `HttpResponseMessage` even though what we really want is `User`.

This change allows for the type specified in ResponseType to be used (as per the Web API Help Pages).
