### PR TITLE
Made ajax options use base url

### DIFF
--- a/WebApiProxy.Server/Templates/JsProxyTemplate.tt
+++ b/WebApiProxy.Server/Templates/JsProxyTemplate.tt
@@ -47,7 +47,7 @@
 		//url += getQueryString(urlParams);
 
 		var ajaxOptions = $.extend({}, this.defaultOptions, {
-			url: appendPathDelimiter($.proxies.baseUrl) + url,
+			url: $.proxies.baseUrl + url,
 			type: type,
 			beforeSend : function(xhr) {
 				if (typeof(webApiAuthToken) != "undefined" && webApiAuthToken.length > 0)


### PR DESCRIPTION
I did this to make the proxies work for my setup.  I have an ASP.NET MVC site at the root domain, and Web API hosted under that.

RootDomain (Asp.Net MVC)
--->/api.  (Web API)

Initially I tried overriding the base url but the way it is setup it produces a hard-coded string.  By switching it to reference $.proxies.baseUrl I can override base url.

$.proxies.baseUrl += "api/";

Preferably I would be able to set this when I setup the route for web api.