### PR TITLE
generic type meta data  repair & nuget cmd improve

### DIFF
--- a/WebApiProxy.Server/MetadataProvider.cs
+++ b/WebApiProxy.Server/MetadataProvider.cs
@@ -101,8 +101,8 @@ namespace WebApiProxy.Server
             {
                 res = GetGenericRepresentation(type, (t) => ParseType(t, model), model);
 
-                    AddModelDefinition(type);
-                }
+                AddModelDefinition(type);
+            }
             else
             {
                 if (type.ToString().StartsWith("System."))
@@ -116,7 +116,10 @@ namespace WebApiProxy.Server
                 {
                     res = type.Name;
 
+                    if (!type.IsGenericParameter)
+                    {
                         AddModelDefinition(type);
+                    }
                 }
             }
 
@@ -154,6 +157,33 @@ namespace WebApiProxy.Server
             return res;
         }
 
+        private string GetGenericTypeDefineRepresentation(Type genericTypeDefClass)
+        {
+
+            string res = genericTypeDefClass.Name;
+            int index = res.IndexOf('`');
+            if (index > -1)
+                res = res.Substring(0, index);
+
+            Type[] args = genericTypeDefClass.GetGenericArguments();
+
+            res += "<";
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (i > 0)
+                    res += ", ";
+
+                var arg = args[i];
+                res += arg.Name;
+            }
+
+            res += ">";
+            return res;
+        }
+
+
+
         private void AddModelDefinition(Type classToDef)
         {
             var documentationProvider = config.Services.GetDocumentationProvider();
@@ -176,7 +206,7 @@ namespace WebApiProxy.Server
                 model.Description = GetDescription(classToDef);
                 if (classToDef.IsGenericType)
                 {
-                    model.Name = GetGenericRepresentation(classToDef, (t) => model.AddGenericArgument(t.Name), model);
+                    model.Name = GetGenericTypeDefineRepresentation(classToDef.GetGenericTypeDefinition());
                 }
                 model.Type = classToDef.IsEnum ? "enum" : "class";
                 var constants = classToDef
@@ -192,14 +222,17 @@ namespace WebApiProxy.Server
                                       Description = GetDescription(constant)
                                   };
 
-                var properties = classToDef.GetProperties();
+                var properties = classToDef.IsGenericType
+                                     ? classToDef.GetGenericTypeDefinition().GetProperties()
+                                     : classToDef.GetProperties();
+            
                 model.Properties = from property in properties
                                    select new ModelProperty
-                                   {
-                                       Name = property.Name,
-                                       Type = ParseType(property.PropertyType, model),
-                                       Description = GetDescription(property)
-                                   };
+                                          {
+                                              Name = property.Name,
+                                              Type = ParseType(property.PropertyType, model),
+                                              Description = GetDescription(property)
+                                          };
                 AddTypeToIgnore(model.Name);
                 foreach (var p in properties)
                 {

--- a/WebApiProxy.Tasks/WebApiProxyCSharp.psm1
+++ b/WebApiProxy.Tasks/WebApiProxyCSharp.psm1
@@ -1,32 +1,35 @@
 ﻿function WebApiProxy-Generate-CSharp() {
+
 	$project = Get-Project
-    
     $projectPath = [System.IO.Path]::GetDirectoryName($project.FullName)
-
 	$root = (Join-Path $projectPath "WebApiProxy\")
-
 	$rootSpaces = "$root"
 
-	$config = [WebApiProxy.Tasks.Models.Configuration]::Load($rootSpaces);
+	$generateJob = Start-Job -ScriptBlock { 
+        param($project,$projectPath,$rootSpace) 
 
-    $generator = New-Object WebApiProxy.Tasks.Infrastructure.CSharpGenerator -ArgumentList @($config)
-    
-    
-    
-    $fileName = (Join-Path $projectPath "WebApiProxy\WebApiProxy.generated.cs")
-    
-	Write-Host "Generating proxy code..."
+		Add-Type -Path (Join-Path $projectPath "bin\Debug\WebApiProxy.Tasks.dll")
+		$config = [WebApiProxy.Tasks.Models.Configuration]::Load($rootSpaces);
 
-    $source = $generator.Generate()
+		$generator = New-Object WebApiProxy.Tasks.Infrastructure.CSharpGenerator -ArgumentList @($config)
+		$fileName = (Join-Path $projectPath "WebApiProxy\WebApiProxy.generated.cs")
     
-    $result = New-Item $fileName `
-          -ItemType "file" -Force `
-          -Value $source
+		Write-Host "Generating proxy code..."
+
+		$source = $generator.Generate()
     
-    $item = $project.ProjectItems.AddFromFile($fileName)
-
-	Write-Host "Done."
-
-}
+		$result = New-Item $fileName `
+			  -ItemType "file" -Force `
+			  -Value $source
+    
+		$item = $project.ProjectItems.AddFromFile($fileName)
+		$source
+		Write-Host "Done..."
+	 } -ArgumentList @($project,$projectPath,$rootSpace)
+	 
+	 $result = Receive-Job -Job $generateJob -Wait
+	 Write-Host $result
+     Write-Host "Done."
+} 
 
 Export-ModuleMember "WebApiProxy-Generate-CSharp"

--- a/WebApiProxy.Tasks/WebApiProxyCSharp.psm1
+++ b/WebApiProxy.Tasks/WebApiProxyCSharp.psm1
@@ -6,9 +6,11 @@
 	$rootSpaces = "$root"
 
 	$generateJob = Start-Job -ScriptBlock { 
-        param($project,$projectPath,$rootSpace) 
+        param($project,$projectPath,$rootSpaces) 
 
 		Add-Type -Path (Join-Path $projectPath "bin\Debug\WebApiProxy.Tasks.dll")
+
+
 		$config = [WebApiProxy.Tasks.Models.Configuration]::Load($rootSpaces);
 
 		$generator = New-Object WebApiProxy.Tasks.Infrastructure.CSharpGenerator -ArgumentList @($config)
@@ -22,10 +24,8 @@
 			  -ItemType "file" -Force `
 			  -Value $source
     
-		$item = $project.ProjectItems.AddFromFile($fileName)
-		$source
-		Write-Host "Done..."
-	 } -ArgumentList @($project,$projectPath,$rootSpace)
+		# $item = $project.ProjectItems.AddFromFile($fileName)
+	 } -ArgumentList @($project,$projectPath,$rootSpaces)
 	 
 	 $result = Receive-Job -Job $generateJob -Wait
 	 Write-Host $result

--- a/WebApiProxy.Tasks/init.ps1
+++ b/WebApiProxy.Tasks/init.ps1
@@ -1,4 +1,3 @@
 ﻿param($installPath, $toolsPath, $package)
 
-Add-Type -Path (Join-Path $installPath "build\WebApiProxy.Tasks.dll")
 Import-Module (Join-Path $toolsPath "WebApiProxyCSharp.psm1") -DisableNameChecking


### PR DESCRIPTION
* change nuget generate cmd run in job
* make generic type meta data generate correctly

# change nuget generate cmd run in job

in init.ps1 script , we add-type to app-domain, when we update pkg, the cmd will use old one if we didn't restart visual studio.

so i change run generate cmd in job , each time we run the cmd, we use the latest pkg under `bin\xxx`.

# make generic type meta data generate correctly

when we use a generic type, like this:

``` csharp
  public class ValuesController : ApiController
    {
        // GET api/values
        public TestGeneric<string> Get()
        {
            return new TestGeneric<string>()
                   {
                       Code = 200,
                       Message = "成功",
                       Data1 = "1",
                       Data2 = "2",
                   };
        }

        // GET api/values/5
        public TestGeneric<int> Get(int id)
        {
            return new TestGeneric<int>()
                   {
                       Code = 200,
                       Message = "成功",
                       Data1 = 1,
                       Data2 = 2,
                   };
        }
      
    }


    public class TestGeneric<T>
    {
        public int Code { get; set; }

        public string Message { get; set; }

        public T Data1 { get; set; }
        public T Data2 { get; set; }
    }
```

the old one generate code like this :
```csharp
	/// <summary>
	/// 
	/// </summary>
	public partial class TestGeneric<T1>
	{
		#region Constants
		#endregion

		#region Properties
		/// <summary>
		/// 
		/// </summary>
		public virtual Int32 Code { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual String Message { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual String Data1 { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual String Data2 { get; set; }
		#endregion
	}	
```
**the generic param T doesn't apply to the Data1 and Data2.**

i change it like this:
```csharp
	/// <summary>
	/// 
	/// </summary>
	public partial class TestGeneric<T>
	{
		#region Constants
		#endregion

		#region Properties
		/// <summary>
		/// 
		/// </summary>
		public virtual Int32 Code { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual String Message { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual T Data1 { get; set; }
		/// <summary>
		/// 
		/// </summary>
		public virtual T Data2 { get; set; }
		#endregion
	}	
```

# nice work BTW :-)
