### PR TITLE
bumped version to reflect latest on Nuget

### DIFF
--- a/WebApiProxy.Server/Properties/AssemblyInfo.cs
+++ b/WebApiProxy.Server/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyInformationalVersion("1.2.0.*")]
-[assembly: AssemblyVersion("1.2.0.*")]
-[assembly: AssemblyFileVersion("1.2.0.*")]
+[assembly: AssemblyVersion("1.2.1.*")]
+[assembly: AssemblyFileVersion("1.2.1.*")]

--- a/WebApiProxy.Tasks/Properties/AssemblyInfo.cs
+++ b/WebApiProxy.Tasks/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyInformationalVersion("1.0.4.*")]
-[assembly: AssemblyVersion("1.0.4.*")]
-[assembly: AssemblyFileVersion("1.0.4.*")]
+[assembly: AssemblyVersion("1.0.5.*")]
+[assembly: AssemblyFileVersion("1.0.5.*")]


### PR DESCRIPTION
For some reason the latest version of Nuget was 1 version ahead. This should fix it now.