### PR TITLE
Update CSharpProxyTemplate.tt

### DIFF
--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -35,7 +35,7 @@ namespace <#= Configuration.Namespace#>
 		/// <summary>
 		/// Web Api Base Address.
 		/// </summary>
-		public static string <#= Configuration.Name #>BaseAddress = "<#= Configuration.Metadata.Host #>";
+		public static string <#= Configuration.Name #>BaseAddress = "<#= Configuration.Metadata.Host #>/";
 	}
 }
 #endregion


### PR DESCRIPTION
I discovered that calls to HttpClient.GetAsync in the WebApiProxy.generated.cs file were returning a 404 after I added an additional directory to my Web API path, eg, http://localhost/AdditionalDirectory/api/Values.  I was able to use the API (with the additional directory) from a web browser. When I examined the request Uri, it was http://localhost/api/Values, rather than http://localhost/AdditionalDirectory/api/Values.  I verified MyWebApiProxyBaseAddress was set correctly.  In my effort to figure out what was going on, I cam across this SO question/answer, http://stackoverflow.com/a/23438417/640326.  I manually added a slash to the end of MyWebApiProxyBaseAddress, and everything worked as expected.  It looks like adding a slash just before the last quote in CSharpProxyTemplate.tt, line 38 should work?