### PR TITLE
Make DateTime parameters culture invariant

### DIFF
--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.cs
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.cs
@@ -835,7 +835,10 @@ using ");
 
 		var postOrPutOrPatch =  method.Type.ToTitle() == "Post" || method.Type.ToTitle() == "Put" || method.Type.ToTitle() == "Patch";
 		var url = ("\"" + method.Url.Replace("{", "\" + ").Replace("}", " + \"") + "\"").Replace(" + \"\"","");
-
+		
+		allParameters.Where(m => m != null && m.Type == "DateTime")
+             		     .ToList()
+		             .ForEach(p => url = url.Replace(" " + p.Name, " " + p.Name + ".ToString(\"o\")"));
             
             #line default
             #line hidden

--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.cs
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.cs
@@ -836,7 +836,7 @@ using ");
 		var postOrPutOrPatch =  method.Type.ToTitle() == "Post" || method.Type.ToTitle() == "Put" || method.Type.ToTitle() == "Patch";
 		var url = ("\"" + method.Url.Replace("{", "\" + ").Replace("}", " + \"") + "\"").Replace(" + \"\"","");
 		
-		allParameters.Where(m => m != null && m.Type == "DateTime")
+		allParameters.Where(m => m != null && (m.Type == "DateTime" || m.Type == "Nullable<DateTime>"))
              		     .ToList()
 		             .ForEach(p => url = url.Replace(" " + p.Name, " " + p.Name + ".ToString(\"o\")"));
             

--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -367,7 +367,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		var postOrPutOrPatch =  method.Type.ToTitle() == "Post" || method.Type.ToTitle() == "Put" || method.Type.ToTitle() == "Patch";
 		var url = ("\"" + method.Url.Replace("{", "\" + ").Replace("}", " + \"") + "\"").Replace(" + \"\"","");
 		
-		allParameters.Where(m => m != null && m.Type == "DateTime")
+		allParameters.Where(m => m != null && (m.Type == "DateTime" || m.Type == "Nullable<DateTime>"))
 		             .ToList()
 		             .ForEach(p => url = url.Replace(" " + p.Name, " " + p.Name + ".ToString(\"o\")"));
 		             

--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -366,6 +366,11 @@ namespace <#= Configuration.Namespace#>.Clients
 
 		var postOrPutOrPatch =  method.Type.ToTitle() == "Post" || method.Type.ToTitle() == "Put" || method.Type.ToTitle() == "Patch";
 		var url = ("\"" + method.Url.Replace("{", "\" + ").Replace("}", " + \"") + "\"").Replace(" + \"\"","");
+		
+		allParameters.Where(m => m != null && m.Type == "DateTime")
+		             .ToList()
+		             .ForEach(p => url = url.Replace(" " + p.Name, " " + p.Name + ".ToString(\"o\")"));
+		             
 #>
 		/// <summary>
 		/// <#= method.Description.ToSummary() #>


### PR DESCRIPTION
For DateTime parameters the default ToString will look into the CurrentCulture to determine the dateformat. This pull request fixes this with the solution proposed in #70 by @wolfen351.