### PR TITLE
Apply async best practices in libraries

### DIFF
--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -1,4 +1,4 @@
-﻿<#@ template language="C#" #>
+<#@ template language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using System.Net.Http.Formatting;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Web;
 using <#= Configuration.Namespace#>.Models;
 
@@ -139,9 +140,9 @@ namespace <#= Configuration.Namespace#>.Interfaces
 
 <# if (Configuration.GenerateAsyncReturnTypes == false || String.IsNullOrEmpty(concreteReturnType)) { #>
 		/// <returns></returns>
-		Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#>);
+		Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken);
 <# } else { #>
-		Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#>);
+		Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken);
 <# } #>
 
 <# foreach(var p in method.UrlParameters) {#>
@@ -379,9 +380,9 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// <param name="<#= p.Name #>"><#= p.Description.ToSummary() #></param>
 <# } #>
 		/// <returns></returns>
-		protected virtual async Task<HttpResponseMessage> <#= method.Name #>AsyncMsg(<#= parameterList#>)
+		protected virtual async Task<HttpResponseMessage> <#= method.Name #>AsyncMsg(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken = default(CancellationToken))
 		{
-			return await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>);
+			return await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>, cancellationToken).ConfigureAwait(false);
 		}
 
 <# if (Configuration.GenerateAsyncReturnTypes == false || String.IsNullOrEmpty(concreteReturnType)) { #>
@@ -392,9 +393,9 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// <param name="<#= p.Name #>"><#= p.Description.ToSummary() #></param>
 <# } #>
 		/// <returns></returns>
-		public virtual async Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#>)
+		public virtual async Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken = default(CancellationToken))
 		{
-			return await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>);
+			return await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>, cancellationToken).ConfigureAwait(false);
 		}
 
 <# } else { #>
@@ -405,9 +406,9 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// <param name="<#= p.Name #>"><#= p.Description.ToSummary() #></param>
 <# } #>
 		/// <returns></returns>
-		public virtual async Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#>)
+		public virtual async Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken = default(CancellationToken))
 		{
-			var result = await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>);
+			var result = await HttpClient.<#=method.Type.ToTitle()#><#= postOrPutOrPatch ? "AsJson" : "" #>Async<#= postOrPutOrPatch && method.BodyParameter != null ? "<" + method.BodyParameter.Type + ">" : "" #>(<#=url#><#= postOrPutOrPatch ? bodyParameterString:""#>, cancellationToken).ConfigureAwait(false);
 			 
 			EnsureSuccess(result);
 				 
@@ -437,4 +438,3 @@ namespace <#= Configuration.Namespace#>.Clients
 <# } #>
 }
 #endregion
-

--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -140,9 +140,9 @@ namespace <#= Configuration.Namespace#>.Interfaces
 
 <# if (Configuration.GenerateAsyncReturnTypes == false || String.IsNullOrEmpty(concreteReturnType)) { #>
 		/// <returns></returns>
-		Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken);
+		Task<HttpResponseMessage> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken = default(CancellationToken));
 <# } else { #>
-		Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken);
+		Task<<#= concreteReturnType #>> <#= method.Name #>Async(<#= parameterList#><#= parameterList.Any() ? ", " : "" #>CancellationToken cancellationToken = default(CancellationToken));
 <# } #>
 
 <# foreach(var p in method.UrlParameters) {#>


### PR DESCRIPTION
Added the possibility to pass a cancellation token in the async calls + call the HttpClient methods with the .ConfigureAwait(false) option.