### PR TITLE
Backwards compatibility for null-parameters

### DIFF
--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -218,7 +218,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// </summary>
 		protected string EncodeParam(DateTime value) 
 		{
-			return System.Net.WebUtility.UrlEncode(value?.ToString("o"));
+			return System.Net.WebUtility.UrlEncode(value.ToString("o"));
 		}
 		
 		/// <summary>
@@ -226,7 +226,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// </summary>
 		protected string EncodeParam(DateTimeOffset value)
 		{
-			return System.Net.WebUtility.UrlEncode(value?.ToString("o"));
+			return System.Net.WebUtility.UrlEncode(value.ToString("o"));
 		}
 		
 		/// <summary>

--- a/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
+++ b/WebApiProxy.Tasks/Templates/CSharpProxyTemplate.tt
@@ -210,7 +210,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// </summary>
 		protected string EncodeParam<T>(T value) 
 		{
-			return System.Net.WebUtility.UrlEncode(value.ToString());
+			return System.Net.WebUtility.UrlEncode(value?.ToString());
 		}
 
 		/// <summary>
@@ -218,7 +218,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// </summary>
 		protected string EncodeParam(DateTime value) 
 		{
-			return System.Net.WebUtility.UrlEncode(value.ToString("o"));
+			return System.Net.WebUtility.UrlEncode(value?.ToString("o"));
 		}
 		
 		/// <summary>
@@ -226,7 +226,7 @@ namespace <#= Configuration.Namespace#>.Clients
 		/// </summary>
 		protected string EncodeParam(DateTimeOffset value)
 		{
-			return System.Net.WebUtility.UrlEncode(value.ToString("o"));
+			return System.Net.WebUtility.UrlEncode(value?.ToString("o"));
 		}
 		
 		/// <summary>


### PR DESCRIPTION
In previous versions it was possible to pass null parameters to the proxy operations. With the EncodeParam operation the null parameters cause a NullReferenceException on the value.ToString operation. This change adds a Safe Navigation Operation to prevent the NullReferenceException .